### PR TITLE
README.md: don't pass `/etc/` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ docker run\
  --rm\
  -i\
  -t\
- -v /etc/group:/etc/group:ro\
- -v /etc/passwd:/etc/passwd:ro\
  -u=$(id -u):$(id -g)\
  --name connect-automation-container\
  "linaroits/connect-automation:$( git rev-parse --short HEAD )"\


### PR DESCRIPTION
I put those for troubleshooting during development (and due to cargo-culting in my memory!): it's not required, so should be removed.